### PR TITLE
Separate build and install environments to emulate binary ROS install.

### DIFF
--- a/installROS2.sh
+++ b/installROS2.sh
@@ -13,7 +13,8 @@
 ROS_PKG=ros_base
 ROS_DISTRO=foxy
 # Core ROS2 workspace - the "underlay"
-ROS_ROOT=/opt/ros/${ROS_DISTRO}
+ROS_BUILD_ROOT=/opt/ros/${ROS_DISTRO}-src
+ROS_INSTALL_ROOT=/opt/ros/${ROS_DISTRO}
 
 locale  # check for UTF-8
 
@@ -83,36 +84,37 @@ git clone --branch yaml-cpp-0.6.0 https://github.com/jbeder/yaml-cpp yaml-cpp-0.
 
 
 # https://answers.ros.org/question/325245/minimal-ros2-installation/?answer=325249#post-id-325249
-sudo mkdir -p ${ROS_ROOT}/src && \
-  cd ${ROS_ROOT}
+sudo mkdir -p ${ROS_BUILD_ROOT}/src && \
+  cd ${ROS_BUILD_ROOT}
 sudo sh -c "rosinstall_generator --deps --rosdistro ${ROS_DISTRO} ${ROS_PKG} launch_xml launch_yaml example_interfaces > ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
 cat ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall && \
     vcs import src < ros2.${ROS_DISTRO}.${ROS_PKG}.rosinstall"
 
 # download unreleased packages     
-sudo sh -c "git clone --branch ros2 https://github.com/Kukanani/vision_msgs ${ROS_ROOT}/src/vision_msgs && \
+sudo sh -c "git clone --branch ros2 https://github.com/Kukanani/vision_msgs ${ROS_BUILD_ROOT}/src/vision_msgs && \
     git clone --branch ${ROS_DISTRO} https://github.com/ros2/demos demos && \
-    cp -r demos/demo_nodes_cpp ${ROS_ROOT}/src && \
-    cp -r demos/demo_nodes_py ${ROS_ROOT}/src && \
+    cp -r demos/demo_nodes_cpp ${ROS_BUILD_ROOT}/src && \
+    cp -r demos/demo_nodes_py ${ROS_BUILD_ROOT}/src && \
     rm -r -f demos"
 
 # install dependencies using rosdep
 sudo apt-get update
-    cd ${ROS_ROOT} 
+    cd ${ROS_BUILD_ROOT} 
 sudo rosdep init  
     rosdep update && \
     rosdep install --from-paths src --ignore-src --rosdistro ${ROS_DISTRO} -y --skip-keys "console_bridge fastcdr fastrtps rti-connext-dds-5.3.1 urdfdom_headers qt_gui" && \
     sudo rm -rf /var/lib/apt/lists/*
 
 # build it!
+sudo mkdir -p ${ROS_INSTALL_ROOT}
 # sudo required to write build logs
-sudo colcon build --symlink-install
+sudo colcon build --merge-install --install-base ${ROS_INSTALL_ROOT}
 # We do this twice to make sure everything gets built
 # For some reason, this has been an issue
-sudo colcon build --symlink-install
+sudo colcon build --merge-install --install-base ${ROS_INSTALL_ROOT}
 
 # Using " expands environment variable immediately
-echo "source $ROS_ROOT/install/setup.bash" >> ~/.bashrc 
+echo "source $ROS_INSTALL_ROOT/setup.bash" >> ~/.bashrc 
 echo "source /usr/share/colcon_cd/function/colcon_cd.sh" >> ~/.bashrc
 echo "export _colcon_cd_root=~/ros2_install" >> ~/.bashrc
 


### PR DESCRIPTION
This change allows the folder `/opt/ros/foxy` to have the same contents as if the packages were installed from the build farm repositories (binaries). 